### PR TITLE
Add runtime config options for Slurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ export LLAMA_SERVER_URL=http://node123:8000
 ```
 Passenger passes environment variables through to `app.js`, which can read `process.env.LLAMA_SERVER_URL` to forward requests.
 
+### Runtime configuration
+Several environment variables control how the Slurm job is launched. All have sane defaults and are optional:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SLURM_PARTITION` | `gpu` | Slurm partition used when submitting the job |
+| `GPU_TYPE` | `gpu:1` | `--gres` value specifying the GPU resource requirement |
+| `LLAMA_ARGS` | *(empty)* | Extra command line arguments passed to `llama.cpp` |
+| `LLAMA_SERVER_PORT` | `8000` | Port the server listens on |
+
+These can be set in your shell before launching the app:
+```bash
+export SLURM_PARTITION=debug
+export GPU_TYPE=gpu:a100:1
+export LLAMA_ARGS="--n-gpu-layers 40"
+export LLAMA_SERVER_PORT=8001
+```
+
 ## Basic usage
 1. Start the Slurm job running `llama.cpp` as shown above.
 2. Set `LLAMA_SERVER_URL` in your environment.

--- a/nextjs/config.js
+++ b/nextjs/config.js
@@ -1,0 +1,10 @@
+const config = {
+  baseUri: process.env.PASSENGER_BASE_URI || '/',
+  llamaServerUrl: process.env.LLAMA_SERVER_URL || null,
+  llamaServerPort: process.env.LLAMA_SERVER_PORT || 8000,
+  slurmPartition: process.env.SLURM_PARTITION || 'gpu',
+  gpuType: process.env.GPU_TYPE || 'gpu:1',
+  llamaArgs: process.env.LLAMA_ARGS || '',
+};
+
+module.exports = config;

--- a/nextjs/scripts/run_llama.sh
+++ b/nextjs/scripts/run_llama.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #SBATCH --job-name=llama_server
 #SBATCH --nodes=1
-#SBATCH --gres=gpu:1
+#SBATCH --gres=${GPU_TYPE:-gpu:1}
+#SBATCH --partition=${SLURM_PARTITION:-gpu}
 #SBATCH --time=02:00:00
 #SBATCH --output=llama_%j.log
 
@@ -12,8 +13,9 @@
 PORT=${PORT:-8000}
 LLAMA_CPP_BIN=${LLAMA_CPP_BIN:-/path/to/llama.cpp/server}
 MODEL=${MODEL:-/path/to/models/llama-7b.gguf}
+LLAMA_ARGS=${LLAMA_ARGS:-}
 
 module load cuda >/dev/null 2>&1 || true
 
-srun "$LLAMA_CPP_BIN" -m "$MODEL" --port "$PORT" --host 0.0.0.0
+srun "$LLAMA_CPP_BIN" -m "$MODEL" --port "$PORT" --host 0.0.0.0 $LLAMA_ARGS
 


### PR DESCRIPTION
## Summary
- centralize configuration in `config.js`
- support GPU type, Slurm partition and extra server args via env vars
- document the new environment variables

## Testing
- `npm install --production`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68767f6392208324aec26a93bd7156bc