### PR TITLE
Fix root baseUri path rewriting

### DIFF
--- a/nextjs/app.js
+++ b/nextjs/app.js
@@ -141,7 +141,10 @@ app.prepare().then(() => {
   // Mount under the base URI
   server.use(baseUri, (req, res) => {
     // Strip off the base path before handing to Next
-    req.url = req.url.replace(new RegExp(`^${baseUri}`), '') || '/';
+    const stripped = baseUri === '/'
+      ? req.url
+      : req.url.replace(new RegExp(`^${baseUri}`), '') || '/';
+    req.url = stripped;
     return handle(req, res);
   });
 


### PR DESCRIPTION
## Summary
- handle `baseUri` `/` correctly so Next.js asset paths remain valid

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687692bb6de88324b7c9313aacd9dee9