### PR TITLE
Fix stylesheet loading via base path config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,5 @@
+const config = require('./config');
+module.exports = {
+  basePath: config.baseUri === '/' ? '' : config.baseUri.replace(/\/$/, ''),
+  assetPrefix: config.baseUri,
+};


### PR DESCRIPTION
## Summary
- configure Next.js basePath and assetPrefix so the app works when mounted under a subpath

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68769d667b508324adcee50fb420a44d