### PR TITLE
Fix stylesheet loading via base path config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
    npm install --production
    ```
 3. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
+4. If the app is mounted under a different subpath, set `PASSENGER_BASE_URI` to that path before running `npm run build` so static assets load correctly.
 
 ## Launching the LLaMA.cpp server with Slurm
 The front end expects an instance of `llama.cpp` started in server mode. An example interactive job might be:

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+const config = require('./config');
+const prefix = config.baseUri.replace(/\/$/, '');
+
+module.exports = {
+  basePath: prefix === '/' ? '' : prefix,
+  assetPrefix: prefix === '/' ? '' : prefix,
+};


### PR DESCRIPTION
## Summary
- configure Next.js basePath and assetPrefix so the app works when mounted under a subpath
- document the PASSENGER_BASE_URI build step

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68769d667b508324adcee50fb420a44d