### PR TITLE
Add env.local support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for the OOD LLM app
+# Copy this file to .env.local and adjust the values as needed
+
+SLURM_PARTITION=gpu
+GPU_TYPE=gpu:1
+PASSENGER_BASE_URI=/
+LLAMA_CPP_BIN=/path/to/llama.cpp/server
+MODEL=/path/to/models/llama-7b.gguf
+LLAMA_ARGS=
+LLAMA_SERVER_PORT=8000
+SESSION_TIMEOUT=600

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env.local

--- a/README.md
+++ b/README.md
@@ -26,20 +26,11 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
 3. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
 
 ## Launching the LLaMA.cpp server with Slurm
-The front end expects an instance of `llama.cpp` started in server mode. An example interactive job might be:
-```bash
-salloc -N1 -c 32 --gres=gpu:1 --mem=64G -t 02:00:00
-module load cuda
-/path/to/llama.cpp/server -m /path/to/models/llama-7b --port 8000
-```
-Adjust the resources to match your model size. The job should remain running so the passenger app can connect. Note the node name (e.g. `node123`) where the server is started.
-
-## Connecting the passenger app
-Before launching the OOD app, set the following environment variable so the front end knows where to reach the backend:
-```bash
-export LLAMA_SERVER_URL=http://node123:8000
-```
-Passenger passes environment variables through to `app.js`, which can read `process.env.LLAMA_SERVER_URL` to forward requests.
+When a user visits the web interface the application automatically submits a Slurm job
+using the `scripts/run_llama.sh` script.  The script starts
+`llama.cpp` in server mode on the allocated node.  Edit the script or set the
+environment variables below so it can locate your built `llama.cpp` binary and
+model file.
 
 ### Runtime configuration
 Several environment variables control how the Slurm job is launched. All have sane defaults and are optional:
@@ -48,23 +39,31 @@ Several environment variables control how the Slurm job is launched. All have sa
 | --- | --- | --- |
 | `SLURM_PARTITION` | `gpu` | Slurm partition used when submitting the job |
 | `GPU_TYPE` | `gpu:1` | `--gres` value specifying the GPU resource requirement |
+| `PASSENGER_BASE_URI` | `/` | Base URI where the app is mounted |
+| `LLAMA_CPP_BIN` | `/path/to/llama.cpp/server` | Path to the `llama.cpp` server executable |
+| `MODEL` | `/path/to/models/llama-7b.gguf` | GGUF model file to load |
 | `LLAMA_ARGS` | *(empty)* | Extra command line arguments passed to `llama.cpp` |
 | `LLAMA_SERVER_PORT` | `8000` | Port the server listens on |
 | `SESSION_TIMEOUT` | `600` | Seconds of inactivity before the job is cancelled |
 
-These can be set in your shell before launching the app:
+Copy `.env.example` to `.env.local` and edit it to set these variables. The file
+is loaded automatically when the server starts and overrides existing
+environment variables.
+
+Set any of these variables in your shell before launching the app:
 ```bash
 export SLURM_PARTITION=debug
 export GPU_TYPE=gpu:a100:1
+export LLAMA_CPP_BIN=/software/llama.cpp/server
+export MODEL=/software/models/llama-7b.gguf
 export LLAMA_ARGS="--n-gpu-layers 40"
 export LLAMA_SERVER_PORT=8001
 ```
 
 ## Basic usage
-1. Start the Slurm job running `llama.cpp` as shown above.
-2. Set `LLAMA_SERVER_URL` in your environment.
-3. Launch the **ood_llm** app from the OOD dashboard.
-4. Navigate to the app URL; enter a prompt and submit it to get a response from the LLaMA server.
+1. Launch the **ood_llm** app from the OOD dashboard.
+2. Visit the app URL. Opening the page submits the Slurm job automatically and connects once `llama.cpp` is ready.
+3. Enter a prompt in the chat box to interact with the model.
 
 This setup allows users to interact with large language models through the comfort of a web browser while leveraging their institution's HPC resources.
 

--- a/config.js
+++ b/config.js
@@ -1,3 +1,9 @@
+const path = require('path');
+require('dotenv').config({
+  path: path.join(__dirname, '.env.local'),
+  override: true,
+});
+
 const config = {
   baseUri: process.env.PASSENGER_BASE_URI || '/',
   llamaServerUrl: process.env.LLAMA_SERVER_URL || null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs",
       "version": "1.0.0",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "http-proxy-middleware": "^3.0.5",
@@ -3585,6 +3586,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "http-proxy-middleware": "^3.0.5",
     "next": "^15.3.5",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
## Summary
- create `.env.example` with Slurm job variables
- load `.env.local` automatically via dotenv
- ignore `.env.local` in git
- document environment file usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876c38b86f08324a0359ee0ec60b956