### PR TITLE
Add env injection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Example environment configuration
+# Copy this file to `.env.local` and adjust the values as needed.
+# It will be automatically loaded during `npm run build` and `npm start`.
+
+# Base URI where the app is mounted
+PASSENGER_BASE_URI=/
+
+# URL of an existing llama.cpp server. Leave blank to start via Slurm.
+LLAMA_SERVER_URL=
+
+# Port the llama.cpp server listens on
+LLAMA_SERVER_PORT=8000
+
+# Slurm options
+SLURM_PARTITION=gpu
+GPU_TYPE=gpu:1
+
+# Path to llama.cpp server binary and model file
+LLAMA_CPP_BIN=/path/to/llama.cpp/server
+MODEL=/path/to/models/llama-7b.gguf
+
+# Additional arguments passed to llama.cpp
+LLAMA_ARGS=
+
+# Session timeout in seconds
+SESSION_TIMEOUT=600

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
 
 ## Running locally
 1. `npm install`
-2. `npm run dev`
-3. Open <http://localhost:3000> to view the demo page
+2. Copy `.env.example` to `.env.local` and edit values if needed
+3. `npm run dev`
+4. Open <http://localhost:3000> to view the demo page
 
 ## Deploying on Open OnDemand
 1. Copy this repository to your OOD development apps directory, for example:
@@ -55,6 +56,12 @@ export MODEL=/software/models/llama-7b.gguf
 export LLAMA_ARGS="--n-gpu-layers 40"
 export LLAMA_SERVER_PORT=8001
 ```
+
+### Build-time environment injection
+Values in `.env.example` are used as a template for `.env.local`. During
+`npm run build` the script `scripts/generateEnv.js` writes a fresh `.env.local`
+using any matching variables from your shell environment. This allows sensitive
+values to be injected without committing them to the repository.
 
 ## Basic usage
 1. Launch the **ood_llm** app from the OOD dashboard.

--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: '.env.local' });
+
 const config = {
   baseUri: process.env.PASSENGER_BASE_URI || '/',
   llamaServerUrl: process.env.LLAMA_SERVER_URL || null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs",
       "version": "1.0.0",
       "dependencies": {
+        "dotenv": "^16.3.1",
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "http-proxy-middleware": "^3.0.5",
@@ -3585,6 +3586,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "app.js",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/generateEnv.js && next build",
     "start": "NODE_ENV=production node app.js",
     "lint": "eslint .",
     "test": "jest"
@@ -13,6 +13,7 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
+    "dotenv": "^16.3.1",
     "next": "^15.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/scripts/generateEnv.js
+++ b/scripts/generateEnv.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const examplePath = path.join(__dirname, '..', '.env.example');
+const localPath = path.join(__dirname, '..', '.env.local');
+
+// Load example file
+const example = fs.readFileSync(examplePath, 'utf8');
+const lines = example.split(/\r?\n/);
+
+const processed = lines.map(line => {
+  const match = line.match(/^([^#=]+)=(.*)$/);
+  if (!match) return line;
+  const key = match[1].trim();
+  const defaultValue = match[2];
+  const envValue = process.env[key];
+  return `${key}=${envValue !== undefined ? envValue : defaultValue}`;
+}).join('\n');
+
+fs.writeFileSync(localPath, processed);
+console.log(`Generated ${localPath}`);


### PR DESCRIPTION
## Summary
- add `.env.example` as a template for runtime configuration
- create `scripts/generateEnv.js` to build `.env.local` from the template
- load `.env.local` via dotenv in `config.js`
- inject env vars during `npm run build`
- document env steps in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876cee0188c8324a2663df640902b2e