### PR TITLE
Fix fetch URLs for custom base URI

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -7,11 +7,11 @@ export default function Chat() {
 
   useEffect(() => {
     // Kick off the Slurm job if needed
-    fetch('/launch', { method: 'POST' }).catch(() => {});
+    fetch('launch', { method: 'POST' }).catch(() => {});
     const keep = setInterval(() => {
-      fetch('/keepalive', { method: 'POST' }).catch(() => {});
+      fetch('keepalive', { method: 'POST' }).catch(() => {});
     }, 30000);
-    const end = () => navigator.sendBeacon('/end');
+    const end = () => navigator.sendBeacon('end');
     window.addEventListener('beforeunload', end);
     return () => {
       clearInterval(keep);
@@ -32,7 +32,7 @@ export default function Chat() {
     setInput('');
 
     try {
-      const res = await fetch('/api/completion', {
+      const res = await fetch('api/completion', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prompt })


### PR DESCRIPTION
## Summary
- use relative URLs in page fetch calls so requests work under custom base paths

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876d77e1348832493cda157670bc1dd