### PR TITLE
Fix deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
    ```bash
    cp -r ood_llm ~/ondemand/dev/ood_llm
    ```
-2. From a shell on the OOD host install dependencies:
+2. From a shell on the OOD host install dependencies **and build the production bundle**:
    ```bash
    cd ~/ondemand/dev/ood_llm
    npm install --production
+   npm run build
    ```
 3. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
 


### PR DESCRIPTION
## Summary
- mention `npm run build` when deploying on Open OnDemand

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876e69a93488324b0280c5dc58d6602