### PR TITLE
Fix README deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
    cd ~/ondemand/dev/ood_llm
    npm install --production
    ```
-3. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
+3. Build the Next.js application:
+   ```bash
+   npm run build
+   ```
+4. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
 
 ## Launching the LLaMA.cpp server with Slurm
 When a user visits the web interface the application automatically submits a Slurm job


### PR DESCRIPTION
## Summary
- update OOD deployment steps to mention `npm run build`

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876e69a93488324b0280c5dc58d6602