### PR TITLE
Ensure base URI consistency across build and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ export LLAMA_SERVER_URL=http://login.example.com:8001
 ### Build-time environment injection
 Values in `.env.example` are used as a template for `.env.local`. During
 `npm run build` the script `scripts/generateEnv.js` writes a fresh `.env.local`
-using any matching variables from your shell environment. This allows sensitive
-values to be injected without committing them to the repository.
+using any matching variables from your shell environment. **`PASSENGER_BASE_URI`
+must be set before running the build.** The build stores this value in
+`.next/build-meta.json` and the server will refuse to start if the runtime value
+differs. This allows sensitive values to be injected without committing them to
+the repository and prevents accidental reuse of stale builds.
 
 ## Basic usage
 1. Launch the **ood_llm** app from the OOD dashboard.

--- a/app.js
+++ b/app.js
@@ -2,12 +2,27 @@ const express = require('express');
 const next    = require('next');
 const { spawn } = require('child_process');
 const path = require('path');
+const fs = require('fs');
 const { createProxyMiddleware } = require('http-proxy-middleware');
 const session = require('express-session');
 
 const log = require('./logger');
 
 const config = require('./config');
+
+// Ensure runtime baseUri matches value used during build
+try {
+  const metaPath = path.join(__dirname, '.next', 'build-meta.json');
+  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+  if (meta.baseUri && meta.baseUri !== config.baseUri) {
+    console.error(
+      `PASSENGER_BASE_URI mismatch: built with ${meta.baseUri} but running with ${config.baseUri}. Rebuild with the correct value.`
+    );
+    process.exit(1);
+  }
+} catch (err) {
+  // Ignore if meta file missing
+}
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });

--- a/scripts/generateEnv.js
+++ b/scripts/generateEnv.js
@@ -8,14 +8,25 @@ const localPath = path.join(__dirname, '..', '.env.local');
 const example = fs.readFileSync(examplePath, 'utf8');
 const lines = example.split(/\r?\n/);
 
+let baseUri;
 const processed = lines.map(line => {
   const match = line.match(/^([^#=]+)=(.*)$/);
   if (!match) return line;
   const key = match[1].trim();
   const defaultValue = match[2];
   const envValue = process.env[key];
-  return `${key}=${envValue !== undefined ? envValue : defaultValue}`;
+  const value = envValue !== undefined ? envValue : defaultValue;
+  if (key === 'PASSENGER_BASE_URI') baseUri = value;
+  return `${key}=${value}`;
 }).join('\n');
 
 fs.writeFileSync(localPath, processed);
 console.log(`Generated ${localPath}`);
+
+// Save build metadata
+const nextDir = path.join(__dirname, '..', '.next');
+fs.mkdirSync(nextDir, { recursive: true });
+const metaPath = path.join(nextDir, 'build-meta.json');
+const buildMeta = { baseUri };
+fs.writeFileSync(metaPath, JSON.stringify(buildMeta));
+console.log(`Saved ${metaPath}`);


### PR DESCRIPTION
## Summary
- save `PASSENGER_BASE_URI` during build in `scripts/generateEnv.js`
- verify the saved URI on startup in `app.js`
- document the new behaviour in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876e72cec4c8324b881149543a5ff7b