### PR TITLE
Remove manual Passenger base URI setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 # Copy this file to `.env.local` and adjust the values as needed.
 # It will be automatically loaded during `npm run build` and `npm start`.
 
-# Base URI where the app is mounted
-PASSENGER_BASE_URI=/
+# Base URI where the app is mounted (set automatically by Passenger)
+# PASSENGER_BASE_URI=
 
 # URL of an existing llama.cpp server. Leave blank to start via Slurm.
 LLAMA_SERVER_URL=

--- a/README.md
+++ b/README.md
@@ -25,11 +25,7 @@ This repository contains a small [Next.js](https://nextjs.org/) passenger app us
    npm install --production
    npm run build
    ```
-3. Build the Next.js application:
-   ```bash
-   npm run build
-   ```
-4. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
+3. Visit **My Sandbox Apps** on the OOD dashboard and choose **ood_llm** then **Develop**. Passenger will start `node app.js` for you and mount it under `/pun/dev/ood_llm`.
 
 ## Launching the LLaMA.cpp server with Slurm
 When a user visits the web interface the application automatically submits a Slurm job
@@ -45,7 +41,7 @@ Several environment variables control how the Slurm job is launched. All have sa
 | --- | --- | --- |
 | `SLURM_PARTITION` | `gpu` | Slurm partition used when submitting the job |
 | `GPU_TYPE` | `gpu:1` | `--gres` value specifying the GPU resource requirement |
-| `PASSENGER_BASE_URI` | `/` | Base URI where the app is mounted |
+| `PASSENGER_BASE_URI` | *(set by Passenger)* | Base URI where the app is mounted |
 | `LLAMA_SERVER_URL` | *(empty)* | Connect to an existing `llama.cpp` server instead of launching one |
 | `LLAMA_CPP_BIN` | `/path/to/llama.cpp/server` | Path to the `llama.cpp` server executable |
 | `MODEL` | `/path/to/models/llama-7b.gguf` | GGUF model file to load |
@@ -65,15 +61,6 @@ export LLAMA_ARGS="--n-gpu-layers 40"
 export LLAMA_SERVER_PORT=8001
 export LLAMA_SERVER_URL=http://login.example.com:8001
 ```
-
-### Build-time environment injection
-Values in `.env.example` are used as a template for `.env.local`. During
-`npm run build` the script `scripts/generateEnv.js` writes a fresh `.env.local`
-using any matching variables from your shell environment. **`PASSENGER_BASE_URI`
-must be set before running the build.** The build stores this value in
-`.next/build-meta.json` and the server will refuse to start if the runtime value
-differs. This allows sensitive values to be injected without committing them to
-the repository and prevents accidental reuse of stale builds.
 
 ## Basic usage
 1. Launch the **ood_llm** app from the OOD dashboard.

--- a/app.js
+++ b/app.js
@@ -10,19 +10,7 @@ const log = require('./logger');
 
 const config = require('./config');
 
-// Ensure runtime baseUri matches value used during build
-try {
-  const metaPath = path.join(__dirname, '.next', 'build-meta.json');
-  const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
-  if (meta.baseUri && meta.baseUri !== config.baseUri) {
-    console.error(
-      `PASSENGER_BASE_URI mismatch: built with ${meta.baseUri} but running with ${config.baseUri}. Rebuild with the correct value.`
-    );
-    process.exit(1);
-  }
-} catch (err) {
-  // Ignore if meta file missing
-}
+
 
 const dev = process.env.NODE_ENV !== 'production';
 if (!dev) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "app.js",
   "scripts": {
     "dev": "next dev",
-    "build": "node scripts/generateEnv.js && next build",
+    "build": "next build",
     "start": "NODE_ENV=production node app.js",
     "lint": "eslint .",
     "test": "jest"


### PR DESCRIPTION
## Summary
- remove PASSENGER_BASE_URI from `.env.example`
- drop build-time environment injection text from README
- rely on Passenger-provided base URI
- simplify build script

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877daceb2c48324923e007d14b4ae15