### PR TITLE
Handle Passenger NODE_ENV

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,6 +10,12 @@ const log = require('./logger');
 
 const config = require('./config');
 
+// Phusion Passenger sets PASSENGER_APP_ENV instead of NODE_ENV
+// Map it so libraries relying on NODE_ENV behave correctly
+if (!process.env.NODE_ENV && process.env.PASSENGER_APP_ENV) {
+  process.env.NODE_ENV = process.env.PASSENGER_APP_ENV;
+}
+
 // Ensure runtime baseUri matches value used during build
 try {
   const metaPath = path.join(__dirname, '.next', 'build-meta.json');


### PR DESCRIPTION
## Summary
- account for PASSENGER_APP_ENV when NODE_ENV isn't set

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877e256cc108324a9dc2498167135e2