### PR TITLE
Fix base path redirect

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,9 @@ const config = require('./config');
 
 const app = express();
 const router = express.Router();
+if (config.baseUri && !config.baseUri.endsWith('/')) {
+  app.get(config.baseUri, (req, res) => res.redirect(config.baseUri + '/'));
+}
 app.use(config.baseUri || '/', router);
 
 const sessionJobs = {};


### PR DESCRIPTION
## Summary
- add redirect when base path missing trailing slash

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687822c5f3ec83248f7b2d14b5ca80fc