### PR TITLE
Add loading workflow and dynamic slurm startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ of stale files.
 
 ## Basic usage
 1. Launch the **ood_llm** app from the OOD dashboard.
-2. Visit the app URL. Opening the page submits the Slurm job automatically and connects once `llama.cpp` is ready.
+2. Visit the app URL. A loading page appears while the Slurm job launches.
+   Each step is checked off once the job starts, begins running and the socket
+   is reachable. When all are complete the chat interface loads automatically.
 3. Enter a prompt in the chat box to interact with the model.
 4. Invalid URLs will show a simple 404 page.
 

--- a/public/chat.html
+++ b/public/chat.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>RufusAI</title>
+  <link rel="stylesheet" href="RufusAI/styles.css">
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/javascript">
+    const { useState, useEffect, useRef } = React;
+
+    function Chat() {
+      const [messages, setMessages] = useState([]);
+      const [input, setInput] = useState('');
+      const messagesEndRef = useRef(null);
+
+      useEffect(() => {
+        const keep = setInterval(() => {
+          fetch('keepalive', { method: 'POST' }).catch(() => {});
+        }, 30000);
+        const end = () => navigator.sendBeacon('end');
+        window.addEventListener('beforeunload', end);
+        return () => {
+          clearInterval(keep);
+          window.removeEventListener('beforeunload', end);
+          end();
+        };
+      }, []);
+
+      useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, [messages]);
+
+      async function sendMessage() {
+        if (!input.trim()) return;
+        const userMsg = { role: 'user', content: input };
+        setMessages(prev => [...prev, userMsg]);
+        const prompt = input;
+        setInput('');
+        try {
+          const res = await fetch('api/completion', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt })
+          });
+          if (!res.ok) throw new Error(await res.text());
+          const text = await res.text();
+          setMessages(prev => [...prev, { role: 'assistant', content: text }]);
+        } catch (err) {
+          const msg = err.message.includes('LLaMA server not ready')
+            ? 'Server is starting, please wait...'
+            : 'Error: ' + err.message;
+          setMessages(prev => [...prev, { role: 'assistant', content: msg }]);
+        }
+      }
+
+      function handleKeyDown(e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          sendMessage();
+        }
+      }
+
+      return (
+        React.createElement('div', { className: 'chat-container' },
+          React.createElement('div', { className: 'messages' },
+            messages.map((m, i) => (
+              React.createElement('div', { key: i, className: `message ${m.role}` }, m.content)
+            )),
+            React.createElement('div', { ref: messagesEndRef })
+          ),
+          React.createElement('div', { className: 'input-area' },
+            React.createElement('input', {
+              type: 'text',
+              placeholder: 'Send a message',
+              value: input,
+              onChange: e => setInput(e.target.value),
+              onKeyDown: handleKeyDown
+            }),
+            React.createElement('button', { onClick: sendMessage }, 'Send')
+          )
+        )
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Chat));
+  </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,90 +4,29 @@
   <meta charset="utf-8">
   <title>RufusAI</title>
   <link rel="stylesheet" href="RufusAI/styles.css">
-  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
 </head>
 <body>
-  <div id="root"></div>
-  <script type="text/javascript">
-    const { useState, useEffect, useRef } = React;
-
-    function Chat() {
-      const [messages, setMessages] = useState([]);
-      const [input, setInput] = useState('');
-      const messagesEndRef = useRef(null);
-
-      useEffect(() => {
-        fetch('launch', { method: 'POST' }).catch(() => {});
-        const keep = setInterval(() => {
-          fetch('keepalive', { method: 'POST' }).catch(() => {});
-        }, 30000);
-        const end = () => navigator.sendBeacon('end');
-        window.addEventListener('beforeunload', end);
-        return () => {
-          clearInterval(keep);
-          window.removeEventListener('beforeunload', end);
-          end();
-        };
-      }, []);
-
-      useEffect(() => {
-        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-      }, [messages]);
-
-      async function sendMessage() {
-        if (!input.trim()) return;
-        const userMsg = { role: 'user', content: input };
-        setMessages(prev => [...prev, userMsg]);
-        const prompt = input;
-        setInput('');
-        try {
-          const res = await fetch('api/completion', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ prompt })
-          });
-          if (!res.ok) throw new Error(await res.text());
-          const text = await res.text();
-          setMessages(prev => [...prev, { role: 'assistant', content: text }]);
-        } catch (err) {
-          const msg = err.message.includes('LLaMA server not ready')
-            ? 'Server is starting, please wait...'
-            : 'Error: ' + err.message;
-          setMessages(prev => [...prev, { role: 'assistant', content: msg }]);
+  <ul id="steps" class="loading-list">
+    <li id="step-launch">Launching Server...</li>
+    <li id="step-run">Job Running...</li>
+    <li id="step-sock">Socket Connected...</li>
+  </ul>
+  <script>
+    async function poll() {
+      try {
+        const res = await fetch('status');
+        const data = await res.json();
+        if (data.jobId !== null) document.getElementById('step-launch').classList.add('done');
+        if (data.running) document.getElementById('step-run').classList.add('done');
+        if (data.connected) {
+          document.getElementById('step-sock').classList.add('done');
+          window.location.href = 'chat.html';
+          return;
         }
-      }
-
-      function handleKeyDown(e) {
-        if (e.key === 'Enter') {
-          e.preventDefault();
-          sendMessage();
-        }
-      }
-
-      return (
-        React.createElement('div', { className: 'chat-container' },
-          React.createElement('div', { className: 'messages' },
-            messages.map((m, i) => (
-              React.createElement('div', { key: i, className: `message ${m.role}` }, m.content)
-            )),
-            React.createElement('div', { ref: messagesEndRef })
-          ),
-          React.createElement('div', { className: 'input-area' },
-            React.createElement('input', {
-              type: 'text',
-              placeholder: 'Send a message',
-              value: input,
-              onChange: e => setInput(e.target.value),
-              onKeyDown: handleKeyDown
-            }),
-            React.createElement('button', { onClick: sendMessage }, 'Send')
-          )
-        )
-      );
+      } catch (e) {}
+      setTimeout(poll, 3000);
     }
-
-    ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(Chat));
+    fetch('launch', {method: 'POST'}).then(() => poll());
   </script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -65,3 +65,19 @@ body {
 }
 
 .not-found { text-align: center; padding-top: 2rem; font-size: 1.2rem; }
+
+.loading-list {
+  list-style: none;
+  max-width: 400px;
+  margin: 2rem auto;
+  padding: 0;
+}
+
+.loading-list li {
+  padding: 0.5rem 0;
+}
+
+.loading-list li.done::before {
+  content: "\2713 ";
+  color: green;
+}

--- a/scripts/run_llama.sh
+++ b/scripts/run_llama.sh
@@ -10,13 +10,25 @@
 #SBATCH --cpus-per-task=16
 #SBATCH --mem=64G
 
-PORT=${PORT:-8000}
 LLAMA_CPP_BIN=${LLAMA_CPP_BIN:-/path/to/llama.cpp/server}
 MODEL=${MODEL:-/path/to/models/llama-7b.gguf}
 LLAMA_ARGS=${LLAMA_ARGS:-}
 
+# pick a free port between 8080 and 8090
+for p in {8080..8090}; do
+  if ! ss -ltn | awk '{print $4}' | grep -q ":$p$"; then
+    PORT=$p
+    break
+  fi
+done
+
+HOST=$(hostname)
+
 module load cuda >/dev/null 2>&1 || true
 
-srun "$LLAMA_CPP_BIN" -m "$MODEL" --port "$PORT" --host 0.0.0.0 $LLAMA_ARGS
+echo "PORT=$PORT"
+echo "HOST=$HOST"
+
+srun "$LLAMA_CPP_BIN" -m "$MODEL" --port "$PORT" --host "$HOST" --no-webui --alias RufusAI $LLAMA_ARGS
 
 


### PR DESCRIPTION
## Summary
- show a loading screen that launches and polls a Slurm job
- choose a free port and host name from Slurm script
- detect when the job is running and when the socket is reachable
- update app logic to report session status
- document the new launch workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68794408ea58832480c568153d1cba98